### PR TITLE
feat: Category CRUD API

### DIFF
--- a/app.js
+++ b/app.js
@@ -85,10 +85,13 @@ app.use("/api/users", userRouter);
 //config authRouter
 app.use("/api", authRouter);
 
-
 //config questionRouter
 const questionRouter = require("./router/questionRouter")
 app.use("/api/questions", authorizeRole("admin", "teacher"), questionRouter)
+
+// config categoryRouter
+const categoryRouter = require("./router/categoryrouter");
+app.use("/api/categories", categoryRouter);
 
 //config erorhandle
 const erorhandle = require("./middleware/errorhandling");

--- a/controller/categoryController.js
+++ b/controller/categoryController.js
@@ -1,70 +1,20 @@
+const { Category } = require("../models");
 const {
   createCategoryAsync,
   getAllCategoriesAsync,
   getCategoryByIdAsync,
-} = require("../service/categoryService");
-const jwt = require("jsonwebtoken");
-const { jwtConfig } = require("../appConfig");
-const {
-  UserFriendlyException,
-  EntityNotFoundException,
-  ForbiddenException,
-} = require("../common/commonError");
+  softDeleteCategoryByIdAsync,
+  softDeleteCategoriesByIdsAsync,
+  updateCategoryByIdAsync,
+} = require("../service/categoryservice");
 
-const requireAuthUser = req => {
-  const token = req.cookies?.token;
+const { parsePagination } = require("../middleware/pagination");
+const { EntityNotFoundException, ValidationException } = require("../common/commonError");
 
-  if (!token) {
-    throw new UserFriendlyException("Unauthorized - Token not found", 401);
-  }
-  try {
-    return jwt.verify(token, jwtConfig.secret);
-  } catch (error) {
-    throw new UserFriendlyException("Unauthorized - Invalid token", 401);
-  }
-};
-
-const extractRoleNames = roles =>
-  Array.isArray(roles)
-    ? roles.map(role =>
-        typeof role === "string" ? role.toLowerCase() : role.roleName?.toLowerCase()
-      )
-    : [];
-
-const checkPermissionByRole = (roles, allowedRoles = ["admin"]) => {
-  const roleNames = extractRoleNames(roles);
-  const hasPermission = roleNames.some(role => allowedRoles.includes(role));
-
-  if (!hasPermission) {
-    throw new ForbiddenException("No permission to create category", 403);
-  }
-};
-
-const getCategoryAccessFilter = roles => {
-  const roleNames = extractRoleNames(roles);
-
-  if (roleNames.includes("admin")) {
-    return null;
-  }
-
-  return { isPublic: true };
-};
-
-const parsePagination = query => {
-  const page = parseInt(query.page) || 1;
-  const pageSize = parseInt(query.pageSize) || 10;
-  return {
-    offset: (page - 1) * pageSize,
-    limit: pageSize,
-    page,
-    pageSize,
-  };
-};
-
+// POST /api/categories
+// Create a new category with user-provided data
 const createAsync = async (req, res) => {
-  const user = requireAuthUser(req);
-  checkPermissionByRole(user.roles, ["admin"]);
-
+  const user = req.user;
   const categoryData = req.body;
   categoryData.createdBy = user.id;
 
@@ -73,12 +23,11 @@ const createAsync = async (req, res) => {
   res.sendCommonValue(201, "Category created successfully", result);
 };
 
+// GET /api/categories
+// Get paginated list of categories with optional keyword search
 const getAllAsync = async (req, res) => {
-  const user = requireAuthUser(req);
-  const accessFilter = getCategoryAccessFilter(user.roles);
-
+  const accessFilter = req.accessFilter;
   const { offset, limit, page, pageSize } = parsePagination(req.query);
-
   const keyword = req.query.keyword?.trim() || null;
 
   const { rows: categories, count: total } = await getAllCategoriesAsync(
@@ -101,12 +50,11 @@ const getAllAsync = async (req, res) => {
   });
 };
 
+// GET /api/categories/:id
+// Retrieve a specific category by ID, checking access permissions
 const getByIdAsync = async (req, res) => {
-  const user = requireAuthUser(req);
-  const accessFilter = getCategoryAccessFilter(user.roles);
-
+  const accessFilter = req.accessFilter;
   const categoryId = Number(req.params.id);
-
   const category = await getCategoryByIdAsync(categoryId);
 
   if (!category || (accessFilter && category.isPublic === false)) {
@@ -116,20 +64,21 @@ const getByIdAsync = async (req, res) => {
   res.sendCommonValue(200, "Category retrieved successfully", category);
 };
 
+// GET /api/categories/:id/children
+// Retrieve child categories of a given parent category
 const getChildrenByIdAsync = async (req, res) => {
-  const user = requireAuthUser(req);
-  const accessFilter = getCategoryAccessFilter(user.roles);
+  const accessFilter = req.accessFilter;
   const parentId = Number(req.params.id);
 
   const parentCategory = await getCategoryByIdAsync(parentId);
 
+  // Check if parent exists and if access is allowed
   if (!parentCategory || (accessFilter && parentCategory.isPublic === false)) {
     throw new EntityNotFoundException("Category not found", 404);
   }
 
   const { offset, limit, page, pageSize } = parsePagination(req.query);
   const keyword = req.query.keyword?.trim() || null;
-
   const baseFilter = { parentId, ...(accessFilter || {}) };
 
   const { rows: categories, count: total } = await getAllCategoriesAsync(
@@ -153,13 +102,12 @@ const getChildrenByIdAsync = async (req, res) => {
   });
 };
 
+// GET /api/categories/root
+// Retrieve all top-level categories
 const getRootCategoriesAsync = async (req, res) => {
-  const user = requireAuthUser(req);
-  const accessFilter = getCategoryAccessFilter(user.roles);
-
+  const accessFilter = req.accessFilter;
   const { offset, limit, page, pageSize } = parsePagination(req.query);
   const keyword = req.query.keyword?.trim() || null;
-
   const baseFilter = { parentId: null, ...(accessFilter || {}) };
 
   const { rows: categories, count: total } = await getAllCategoriesAsync(
@@ -183,10 +131,97 @@ const getRootCategoriesAsync = async (req, res) => {
   });
 };
 
+// DELETE /api/categories/:id
+// Soft delete a single category by ID after checking it has no children
+const deleteByIdAsync = async (req, res) => {
+  const categoryId = Number(req.params.id);
+
+  const category = await getCategoryByIdAsync(categoryId);
+  if (!category || category.isDeleted) {
+    throw new EntityNotFoundException("Category not found", 404);
+  }
+
+  // Prevent deletion if category still has visible children categories
+  const childCount = await Category.count({
+    where: { parentId: categoryId, isPublic: true, isDeleted: false },
+  });
+
+  if (childCount > 0) {
+    throw new ValidationException(
+      "This category has subcategories. Please delete subcategories first.",
+      400
+    );
+  }
+
+  const deletedCategory = await softDeleteCategoryByIdAsync(categoryId);
+
+  res.sendCommonValue(200, "Category deleted successfully", deletedCategory);
+};
+
+// DELETE /api/categories
+// Soft delete multiple categories by ID after ensuring none have children
+const deleteByIdsAsync = async (req, res) => {
+  const categoryIds = req.body.ids.map(id => Number(id));
+
+  // Check if all provided category IDs exist
+  for (const categoryId of categoryIds) {
+    const category = await getCategoryByIdAsync(categoryId);
+    if (!category || category.isDeleted) {
+      throw new EntityNotFoundException(`Category ${categoryId} not found`, 404);
+    }
+  }
+
+  // Prevent deletion if any category still has visible subcategories
+  const withChildren = [];
+  for (const id of categoryIds) {
+    const childCount = await Category.count({
+      where: { parentId: id, isPublic: true, isDeleted: false },
+    });
+    if (childCount > 0) {
+      withChildren.push(id);
+    }
+  }
+
+  if (withChildren.length > 0) {
+    throw new ValidationException(
+      `Categories [${withChildren.join(", ")}] have subcategories. Please delete subcategories first.`,
+      400
+    );
+  }
+
+  const deletedCategories = await softDeleteCategoriesByIdsAsync(categoryIds);
+
+  return res.sendCommonValue(200, "Categories deleted successfully", deletedCategories);
+};
+
+// PUT /api/categories/:id
+// Update category details by ID
+const updateByIdAsync = async (req, res) => {
+  const categoryId = req.params.id;
+  const user = req.user;
+
+  const category = await getCategoryByIdAsync(categoryId);
+
+  if (!category) {
+    throw new EntityNotFoundException("Category not found", 404);
+  }
+
+  // Collect fields allowed for update
+  const { name, description, icon, isPublic } = req.body;
+  const updateData = { name, description, icon, isPublic };
+
+  const updatedCategory = await updateCategoryByIdAsync(category, updateData, user.id);
+
+  res.sendCommonValue(200, "Category updated successfully", updatedCategory);
+};
+
 module.exports = {
   createAsync,
   getAllAsync,
   getByIdAsync,
   getChildrenByIdAsync,
   getRootCategoriesAsync,
+  deleteByIdAsync,
+  deleteByIdsAsync,
+  updateByIdAsync
 };

--- a/controller/categoryController.js
+++ b/controller/categoryController.js
@@ -1,0 +1,192 @@
+const {
+  createCategoryAsync,
+  getAllCategoriesAsync,
+  getCategoryByIdAsync,
+} = require("../service/categoryService");
+const jwt = require("jsonwebtoken");
+const { jwtConfig } = require("../appConfig");
+const {
+  UserFriendlyException,
+  EntityNotFoundException,
+  ForbiddenException,
+} = require("../common/commonError");
+
+const requireAuthUser = req => {
+  const token = req.cookies?.token;
+
+  if (!token) {
+    throw new UserFriendlyException("Unauthorized - Token not found", 401);
+  }
+  try {
+    return jwt.verify(token, jwtConfig.secret);
+  } catch (error) {
+    throw new UserFriendlyException("Unauthorized - Invalid token", 401);
+  }
+};
+
+const extractRoleNames = roles =>
+  Array.isArray(roles)
+    ? roles.map(role =>
+        typeof role === "string" ? role.toLowerCase() : role.roleName?.toLowerCase()
+      )
+    : [];
+
+const checkPermissionByRole = (roles, allowedRoles = ["admin"]) => {
+  const roleNames = extractRoleNames(roles);
+  const hasPermission = roleNames.some(role => allowedRoles.includes(role));
+
+  if (!hasPermission) {
+    throw new ForbiddenException("No permission to create category", 403);
+  }
+};
+
+const getCategoryAccessFilter = roles => {
+  const roleNames = extractRoleNames(roles);
+
+  if (roleNames.includes("admin")) {
+    return null;
+  }
+
+  return { isPublic: true };
+};
+
+const parsePagination = query => {
+  const page = parseInt(query.page) || 1;
+  const pageSize = parseInt(query.pageSize) || 10;
+  return {
+    offset: (page - 1) * pageSize,
+    limit: pageSize,
+    page,
+    pageSize,
+  };
+};
+
+const createAsync = async (req, res) => {
+  const user = requireAuthUser(req);
+  checkPermissionByRole(user.roles, ["admin"]);
+
+  const categoryData = req.body;
+  categoryData.createdBy = user.id;
+
+  const result = await createCategoryAsync(categoryData);
+
+  res.sendCommonValue(201, "Category created successfully", result);
+};
+
+const getAllAsync = async (req, res) => {
+  const user = requireAuthUser(req);
+  const accessFilter = getCategoryAccessFilter(user.roles);
+
+  const { offset, limit, page, pageSize } = parsePagination(req.query);
+
+  const keyword = req.query.keyword?.trim() || null;
+
+  const { rows: categories, count: total } = await getAllCategoriesAsync(
+    accessFilter,
+    {
+      offset,
+      limit,
+    },
+    keyword
+  );
+
+  res.sendCommonValue(200, "Categories retrieved successfully", {
+    list: categories,
+    pagination: {
+      total,
+      page,
+      pageSize,
+      totalPages: Math.ceil(total / pageSize),
+    },
+  });
+};
+
+const getByIdAsync = async (req, res) => {
+  const user = requireAuthUser(req);
+  const accessFilter = getCategoryAccessFilter(user.roles);
+
+  const categoryId = Number(req.params.id);
+
+  const category = await getCategoryByIdAsync(categoryId);
+
+  if (!category || (accessFilter && category.isPublic === false)) {
+    throw new EntityNotFoundException("Category not found", 404);
+  }
+
+  res.sendCommonValue(200, "Category retrieved successfully", category);
+};
+
+const getChildrenByIdAsync = async (req, res) => {
+  const user = requireAuthUser(req);
+  const accessFilter = getCategoryAccessFilter(user.roles);
+  const parentId = Number(req.params.id);
+
+  const parentCategory = await getCategoryByIdAsync(parentId);
+
+  if (!parentCategory || (accessFilter && parentCategory.isPublic === false)) {
+    throw new EntityNotFoundException("Category not found", 404);
+  }
+
+  const { offset, limit, page, pageSize } = parsePagination(req.query);
+  const keyword = req.query.keyword?.trim() || null;
+
+  const baseFilter = { parentId, ...(accessFilter || {}) };
+
+  const { rows: categories, count: total } = await getAllCategoriesAsync(
+    baseFilter,
+    { offset, limit },
+    keyword
+  );
+
+  if (total === 0) {
+    throw new EntityNotFoundException("No child categories found", 404);
+  }
+
+  res.sendCommonValue(200, "Child categories retrieved successfully", {
+    list: categories,
+    pagination: {
+      total,
+      page,
+      pageSize,
+      totalPages: Math.ceil(total / pageSize),
+    },
+  });
+};
+
+const getRootCategoriesAsync = async (req, res) => {
+  const user = requireAuthUser(req);
+  const accessFilter = getCategoryAccessFilter(user.roles);
+
+  const { offset, limit, page, pageSize } = parsePagination(req.query);
+  const keyword = req.query.keyword?.trim() || null;
+
+  const baseFilter = { parentId: null, ...(accessFilter || {}) };
+
+  const { rows: categories, count: total } = await getAllCategoriesAsync(
+    baseFilter,
+    { offset, limit },
+    keyword
+  );
+
+  if (total === 0) {
+    throw new EntityNotFoundException("No top-level categories found", 404);
+  }
+
+  res.sendCommonValue(200, "Top-level categories retrieved successfully", {
+    list: categories,
+    pagination: {
+      total,
+      page,
+      pageSize,
+      totalPages: Math.ceil(total / pageSize),
+    },
+  });
+};
+
+module.exports = {
+  createAsync,
+  getAllAsync,
+  getByIdAsync,
+  getChildrenByIdAsync,
+  getRootCategoriesAsync,
+};

--- a/middleware/authentication.js
+++ b/middleware/authentication.js
@@ -1,0 +1,30 @@
+const jwt = require("jsonwebtoken");
+const { jwtConfig } = require("../appConfig");
+const { UserFriendlyException } = require("../common/commonError");
+
+/**
+ * Middleware to enforce authentication.
+ * Verifies the JWT from the request cookies and attaches the decoded user payload to req.user.
+ * Throws a UserFriendlyException if the token is missing or invalid.
+ */
+
+const requireAuth = (req, res, next) => {
+  // Extract token from cookies
+  const token = req.cookies?.token;
+
+  // If no token is provided, block the request
+  if (!token) {
+    throw new UserFriendlyException("Unauthorized - Token not found", 401);
+  }
+
+  try {
+    // Verify token signature and expiration; decode payload into req.user
+    req.user = jwt.verify(token, jwtConfig.secret);
+    next();
+  } catch (err) {
+    // If verification fails (expired, tampered, etc.), block the request
+    throw new UserFriendlyException("Unauthorized - Invalid token", 401);
+  }
+};
+
+module.exports = { requireAuth };

--- a/middleware/authorization.js
+++ b/middleware/authorization.js
@@ -1,0 +1,44 @@
+const { ForbiddenException } = require("../common/commonError");
+
+/**
+ * Middleware to check if the current user has one of the allowed roles.
+ * Throws a 403 Forbidden error if permission is denied.
+ */
+const checkPermissionByRole =
+  (...allowedRoles) =>
+  (req, res, next) => {
+    const userRoles = Array.isArray(req.user.roles)
+      ? req.user.roles.map(role =>
+          typeof role === "string" ? role.toLowerCase() : role.roleName?.toLowerCase()
+        )
+      : [];
+
+    // Check if any of the user's roles are in the allowedRoles list
+    const hasPermission = userRoles.some(role => allowedRoles.includes(role));
+
+    if (!hasPermission) {
+      throw new ForbiddenException("No permission", 403);
+    }
+
+    next();
+  };
+
+/**
+ * Middleware to add an access filter to the request based on user roles.
+ * - Admin: no filter (can see all categories)
+ * - Non-admin: only see public categories
+ */
+const getCategoryAccessFilter = (req, res, next) => {
+  const userRoles = Array.isArray(req.user.roles)
+    ? req.user.roles.map(role =>
+        typeof role === "string" ? role.toLowerCase() : role.roleName?.toLowerCase()
+      )
+    : [];
+
+  // Only public categories for non-admins
+  req.accessFilter = userRoles.includes("admin") ? null : { isPublic: true };
+
+  next();
+};
+
+module.exports = { checkPermissionByRole, getCategoryAccessFilter };

--- a/middleware/pagination.js
+++ b/middleware/pagination.js
@@ -1,0 +1,35 @@
+const { query } = require("express-validator");
+
+// Middleware to validate query parameters for pagination
+const paginationValidator = [
+  // Validate that "page" is an optional positive integer
+  query("page").optional().toInt().isInt({ gt: 0 }).withMessage("page must be a positive integer"),
+
+  // Validate that "pageSize" is an optional positive integer
+  query("pageSize")
+    .optional()
+    .toInt()
+    .isInt({ gt: 0 })
+    .withMessage("pageSize must be a positive integer"),
+];
+
+/**
+ * Parse pagination parameters from query string.
+ * Defaults: page = 1, pageSize = 10
+ * Returns offset and limit for database queries, along with original values.
+ */
+const parsePagination = query => {
+  const page = parseInt(query.page) || 1;
+  const pageSize = parseInt(query.pageSize) || 10;
+  return {
+    offset: (page - 1) * pageSize,
+    limit: pageSize,
+    page,
+    pageSize,
+  };
+};
+
+module.exports = {
+  paginationValidator,
+  parsePagination,
+};

--- a/models/demo.js
+++ b/models/demo.js
@@ -1,40 +1,44 @@
-const { DataTypes } = require("sequelize");
-const { sequelize } = require("../db/sequelizedb");
+// models/demo.js
 
-const demo = sequelize.define(
-  "demo",
-  {
-    // Model attributes are defined here
-    id: {
-      type: DataTypes.INTEGER,
-      primaryKey: true,
-      autoIncrement: true,
-      allowNull: false,
+module.exports = (sequelize, DataTypes) => {
+  const Demo = sequelize.define(
+    "Demo",
+    {
+      id: {
+        type: DataTypes.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+        allowNull: false,
+      },
+      title: {
+        type: DataTypes.STRING,
+        allowNull: false,
+      },
+      mark: {
+        type: DataTypes.STRING,
+        allowNull: true,
+      },
+      count: {
+        type: DataTypes.INTEGER,
+        allowNull: true,
+      },
+      active: {
+        // 修正字段名：原来写成 acitve
+        type: DataTypes.BOOLEAN,
+        allowNull: false,
+        defaultValue: true,
+      },
+      dataTime: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        defaultValue: DataTypes.NOW,
+      },
     },
-    title: {
-      type: DataTypes.STRING,
-      allowNull: false,
-    },
-    mark: {
-      type: DataTypes.STRING,
-      allowNull: true,
-    },
-    count: {
-      type: DataTypes.INTEGER,
-      allowNull: true,
-    },
-    acitve: {
-      type: DataTypes.BOOLEAN,
-      defaultValue: true,
-      allowNull: false,
-    },
-    dataTime: {
-      type: DataTypes.DATE,
-      defaultValue: DataTypes.NOW,
-      allowNull: false,
-    },
-  },
-  { timestamps: false, tableName: "demo" }
-);
+    {
+      tableName: "demo",
+      timestamps: false,
+    }
+  );
 
-module.exports = demo;
+  return Demo;
+};

--- a/router/categoryrouter.js
+++ b/router/categoryrouter.js
@@ -1,0 +1,392 @@
+const express = require("express");
+const router = express.Router();
+const {
+  createAsync,
+  getAllAsync,
+  getByIdAsync,
+  getChildrenByIdAsync,
+  getRootCategoriesAsync,
+} = require("../controller/categoryController");
+const { commonValidate } = require("../middleware/expressValidator");
+const { body, param, query } = require("express-validator");
+
+/**
+ * @swagger
+ * components:
+ *   schemas:
+ *     Category:
+ *       type: object
+ *       properties:
+ *         id:
+ *           type: integer
+ *         name:
+ *           type: string
+ *         parentId:
+ *           type: integer
+ *           nullable: true
+ *         isPublic:
+ *           type: boolean
+ *         createdBy:
+ *           type: integer
+ *         createdAt:
+ *           type: string
+ *           format: date-time
+ *         updatedAt:
+ *           type: string
+ *           format: date-time
+ *   responses:
+ *     Unauthorized:
+ *       description: Missing or invalid token
+ *     Forbidden:
+ *       description: No permission
+ *     Conflict:
+ *       description: Entity already exists
+ *
+ * /api/categories:
+ *   post:
+ *     summary: Create a new course category
+ *     tags:
+ *       - Category
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - name
+ *             properties:
+ *               name:
+ *                 type: string
+ *                 description: The name of the category
+ *               parentId:
+ *                 type: integer
+ *                 nullable: true
+ *                 description: ID of parent category (null for top-level)
+ *               isPublic:
+ *                 type: boolean
+ *                 description: Whether this category is visible to students
+ *     responses:
+ *       201:
+ *         description: Category created successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Category'
+ *       400:
+ *         $ref: '#/components/responses/BadRequest'
+ *       401:
+ *         $ref: '#/components/responses/Unauthorized'
+ *       403:
+ *         $ref: '#/components/responses/Forbidden'
+ *       409:
+ *         $ref: '#/components/responses/Conflict'
+ */
+
+router.post(
+  "/",
+  commonValidate([
+    body("name")
+      .isString()
+      .notEmpty()
+      .withMessage("Category name is required")
+      .isLength({ max: 100 })
+      .withMessage("Category name cannot exceed 100 characters"),
+
+    body("parentId").optional({ nullable: true }).isNumeric(),
+
+    body("isPublic").optional().isBoolean(),
+  ]),
+  createAsync
+);
+
+/**
+ * @swagger
+ * /api/categories:
+ *   get:
+ *     summary: Get all course categories
+ *     tags:
+ *       - Category
+ *     parameters:
+ *       - in: query
+ *         name: page
+ *         schema:
+ *           type: integer
+ *           default: 1
+ *         description: Page number
+ *       - in: query
+ *         name: pageSize
+ *         schema:
+ *           type: integer
+ *           default: 10
+ *         description: Number of items per page
+ *       - in: query
+ *         name: keyword
+ *         schema:
+ *           type: string
+ *         description: Keyword to search in category name
+ *     responses:
+ *       200:
+ *         description: Categories retrieved successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 isSuccess:
+ *                   type: boolean
+ *                   example: true
+ *                 status:
+ *                   type: integer
+ *                   example: 200
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     list:
+ *                       type: array
+ *                       items:
+ *                         $ref: '#/components/schemas/Category'
+ *                     pagination:
+ *                       type: object
+ *                       properties:
+ *                         total:
+ *                           type: integer
+ *                         page:
+ *                           type: integer
+ *                         pageSize:
+ *                           type: integer
+ *                         totalPages:
+ *                           type: integer
+ *                 time:
+ *                   type: string
+ *                   format: date-time
+ *                 message:
+ *                   type: string
+ *                   example: Categories retrieved successfully
+ *       401:
+ *         $ref: '#/components/responses/Unauthorized'
+ */
+
+router.get(
+  "/",
+  commonValidate([
+    query("page").optional().toInt().isInt({ gt: 0 }),
+    query("pageSize").optional().toInt().isInt({ gt: 0 }),
+    query("keyword")
+      .optional()
+      .isString()
+      .isLength({ max: 100 })
+      .withMessage("Category name cannot exceed 100 characters"),
+  ]),
+  getAllAsync
+);
+
+/**
+ * @swagger
+ * /api/categories/root:
+ *   get:
+ *     summary: Get all top-level course categories
+ *     tags:
+ *       - Category
+ *     parameters:
+ *       - in: query
+ *         name: page
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           default: 1
+ *         description: Page number
+ *       - in: query
+ *         name: pageSize
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           default: 10
+ *         description: Items per page
+ *       - in: query
+ *         name: keyword
+ *         schema:
+ *           type: string
+ *         description: Keyword to fuzzy-match category name
+ *     responses:
+ *       200:
+ *         description: Top-level categories retrieved successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 isSuccess:
+ *                   type: boolean
+ *                   example: true
+ *                 status:
+ *                   type: integer
+ *                   example: 200
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     list:
+ *                       type: array
+ *                       items:
+ *                         $ref: '#/components/schemas/Category'
+ *                     pagination:
+ *                       type: object
+ *                       properties:
+ *                         total:
+ *                           type: integer
+ *                         page:
+ *                           type: integer
+ *                         pageSize:
+ *                           type: integer
+ *                         totalPages:
+ *                           type: integer
+ *                 time:
+ *                   type: string
+ *                   format: date-time
+ *                 message:
+ *                   type: string
+ *                   example: Top-level categories retrieved successfully
+ *       400:
+ *         $ref: '#/components/responses/BadRequest'
+ *       401:
+ *         $ref: '#/components/responses/Unauthorized'
+ *       404:
+ *         description: No top-level categories found
+ */
+
+router.get(
+  "/root",
+  commonValidate([
+    query("page").optional().toInt().isInt({ gt: 0 }),
+    query("pageSize").optional().toInt().isInt({ gt: 0 }),
+    query("keyword")
+      .optional()
+      .isString()
+      .isLength({ max: 100 })
+      .withMessage("Category name cannot exceed 100 characters"),
+  ]),
+  getRootCategoriesAsync
+);
+
+/**
+ * @swagger
+ * /api/categories/{id}:
+ *   get:
+ *     summary: Get a single category by ID
+ *     tags:
+ *       - Category
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *         description: Category ID
+ *     responses:
+ *       200:
+ *         description: Category retrieved successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Category'
+ *       401:
+ *         $ref: '#/components/responses/Unauthorized'
+ *       404:
+ *         description: Category not found
+ */
+
+router.get("/:id", commonValidate([param("id").exists().bail().isInt({ gt: 0 })]), getByIdAsync);
+
+/**
+ * @swagger
+ * /api/categories/{id}/children:
+ *   get:
+ *     summary: Get child categories of a given category
+ *     tags:
+ *       - Category
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *         description: Parent category ID
+ *       - in: query
+ *         name: page
+ *         schema:
+ *           type: integer
+ *           default: 1
+ *         description: Page number
+ *       - in: query
+ *         name: pageSize
+ *         schema:
+ *           type: integer
+ *           default: 10
+ *         description: Items per page
+ *       - in: query
+ *         name: keyword
+ *         schema:
+ *           type: string
+ *         description: Keyword to search in category name
+ *     responses:
+ *       200:
+ *         description: Child categories retrieved successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 isSuccess:
+ *                   type: boolean
+ *                   example: true
+ *                 status:
+ *                   type: integer
+ *                   example: 200
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     list:
+ *                       type: array
+ *                       items:
+ *                         $ref: '#/components/schemas/Category'
+ *                     pagination:
+ *                       type: object
+ *                       properties:
+ *                         total:
+ *                           type: integer
+ *                         page:
+ *                           type: integer
+ *                         pageSize:
+ *                           type: integer
+ *                         totalPages:
+ *                           type: integer
+ *                 time:
+ *                   type: string
+ *                   format: date-time
+ *                 message:
+ *                   type: string
+ *                   example: Child categories retrieved successfully
+ *       400:
+ *         $ref: '#/components/responses/BadRequest'
+ *       401:
+ *         $ref: '#/components/responses/Unauthorized'
+ *       404:
+ *         description: Parent category not found or has no children
+ */
+
+router.get(
+  "/:id/children",
+  commonValidate([
+    param("id").exists().bail().isInt({ gt: 0 }),
+    query("page").optional().toInt().isInt({ gt: 0 }),
+    query("pageSize").optional().toInt().isInt({ gt: 0 }),
+    query("keyword")
+      .optional()
+      .isString()
+      .isLength({ max: 100 })
+      .withMessage("Category name cannot exceed 100 characters"),
+  ]),
+  getChildrenByIdAsync
+);
+
+module.exports = router;

--- a/router/categoryrouter.js
+++ b/router/categoryrouter.js
@@ -1,14 +1,24 @@
 const express = require("express");
 const router = express.Router();
+
+const { requireAuth } = require("../middleware/authentication");
+const { checkPermissionByRole, getCategoryAccessFilter } = require("../middleware/authorization");
+const { paginationValidator } = require("../middleware/pagination");
+const { commonValidate } = require("../middleware/expressValidator");
+const { body, param, query } = require("express-validator");
+
 const {
   createAsync,
   getAllAsync,
   getByIdAsync,
   getChildrenByIdAsync,
   getRootCategoriesAsync,
+  deleteByIdAsync,
+  deleteByIdsAsync,
+  updateByIdAsync,
 } = require("../controller/categoryController");
-const { commonValidate } = require("../middleware/expressValidator");
-const { body, param, query } = require("express-validator");
+
+router.use(requireAuth);
 
 /**
  * @swagger
@@ -44,7 +54,7 @@ const { body, param, query } = require("express-validator");
  *
  * /api/categories:
  *   post:
- *     summary: Create a new course category
+ *     summary: Create a new course category (admin only)
  *     tags:
  *       - Category
  *     requestBody:
@@ -85,6 +95,7 @@ const { body, param, query } = require("express-validator");
 
 router.post(
   "/",
+  checkPermissionByRole("admin"),
   commonValidate([
     body("name")
       .isString()
@@ -169,9 +180,9 @@ router.post(
 
 router.get(
   "/",
+  getCategoryAccessFilter,
   commonValidate([
-    query("page").optional().toInt().isInt({ gt: 0 }),
-    query("pageSize").optional().toInt().isInt({ gt: 0 }),
+    ...paginationValidator,
     query("keyword")
       .optional()
       .isString()
@@ -256,9 +267,9 @@ router.get(
 
 router.get(
   "/root",
+  getCategoryAccessFilter,
   commonValidate([
-    query("page").optional().toInt().isInt({ gt: 0 }),
-    query("pageSize").optional().toInt().isInt({ gt: 0 }),
+    ...paginationValidator,
     query("keyword")
       .optional()
       .isString()
@@ -295,7 +306,12 @@ router.get(
  *         description: Category not found
  */
 
-router.get("/:id", commonValidate([param("id").exists().bail().isInt({ gt: 0 })]), getByIdAsync);
+router.get(
+  "/:id",
+  getCategoryAccessFilter,
+  commonValidate([param("id").exists().bail().isInt({ gt: 0 })]),
+  getByIdAsync
+);
 
 /**
  * @swagger
@@ -376,10 +392,10 @@ router.get("/:id", commonValidate([param("id").exists().bail().isInt({ gt: 0 })]
 
 router.get(
   "/:id/children",
+  getCategoryAccessFilter,
   commonValidate([
     param("id").exists().bail().isInt({ gt: 0 }),
-    query("page").optional().toInt().isInt({ gt: 0 }),
-    query("pageSize").optional().toInt().isInt({ gt: 0 }),
+    ...paginationValidator,
     query("keyword")
       .optional()
       .isString()
@@ -387,6 +403,252 @@ router.get(
       .withMessage("Category name cannot exceed 100 characters"),
   ]),
   getChildrenByIdAsync
+);
+
+/**
+ * @swagger
+ * /api/categories:
+ *   delete:
+ *     summary: Soft delete multiple categories (admin only)
+ *     tags:
+ *       - Category
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - ids
+ *             properties:
+ *               ids:
+ *                 type: array
+ *                 description: Array of category IDs to delete
+ *                 items:
+ *                   type: integer
+ *     responses:
+ *       '200':
+ *         description: Categories deleted successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 isSuccess:
+ *                   type: boolean
+ *                 status:
+ *                   type: integer
+ *                 data:
+ *                   type: array
+ *                   description: List of deleted category objects
+ *                   items:
+ *                     $ref: '#/components/schemas/Category'
+ *                 time:
+ *                   type: string
+ *                   format: date-time
+ *                 message:
+ *                   type: string
+ *             example:
+ *               isSuccess: true
+ *               status: 200
+ *               data:
+ *                 - id: 8
+ *                   name: "Graphic Design"
+ *                   description: "Illustration and visual design"
+ *                   icon: "https://example.com/icons/frontend.png"
+ *                   parentId: 6
+ *                   isPublic: false
+ *                   createdBy: 1
+ *                   updatedBy: 1
+ *                   isDeleted: true
+ *                   deletedAt: "2025-07-04T15:01:41.000Z"
+ *                   createdAt: "2025-06-20T09:42:07.000Z"
+ *                   updatedAt: "2025-07-04T15:01:41.000Z"
+ *                 - id: 9
+ *                   name: "JavaScript"
+ *                   description: null
+ *                   icon: null
+ *                   parentId: 2
+ *                   isPublic: false
+ *                   createdBy: 1
+ *                   updatedBy: null
+ *                   isDeleted: true
+ *                   deletedAt: "2025-07-04T15:01:41.000Z"
+ *                   createdAt: "2025-06-27T12:54:11.000Z"
+ *                   updatedAt: "2025-07-04T15:01:41.000Z"
+ *               time: "2025-07-04T15:01:41.554Z"
+ *               message: "Categories deleted successfully"
+ *       '400':
+ *         $ref: '#/components/responses/BadRequest'
+ *       '401':
+ *         $ref: '#/components/responses/Unauthorized'
+ *       '403':
+ *         $ref: '#/components/responses/Forbidden'
+ *       '404':
+ *         description: One or more categories not found
+ */
+
+router.delete(
+  "/",
+  checkPermissionByRole("admin"),
+  commonValidate([body("ids").isArray({ min: 1 }), body("ids.*").isInt({ gt: 0 })]),
+  deleteByIdsAsync
+);
+
+/**
+ * @swagger
+ * /api/categories/{id}:
+ *   delete:
+ *     summary: Soft delete a category (admin only)
+ *     tags:
+ *       - Category
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *         description: Category ID
+ *     responses:
+ *       '200':
+ *         description: Category deleted successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 isSuccess:
+ *                   type: boolean
+ *                 status:
+ *                   type: integer
+ *                 data:
+ *                   $ref: '#/components/schemas/Category'
+ *                 time:
+ *                   type: string
+ *                   format: date-time
+ *                 message:
+ *                   type: string
+ *             example:
+ *               isSuccess: true
+ *               status: 200
+ *               data:
+ *                 id: 11
+ *                 name: "Marketing"
+ *                 description: null
+ *                 icon: null
+ *                 parentId: 10
+ *                 isPublic: false
+ *                 createdBy: 1
+ *                 updatedBy: null
+ *                 isDeleted: true
+ *                 deletedAt: "2025-07-04T14:56:50.000Z"
+ *                 createdAt: "2025-07-04T09:41:03.000Z"
+ *                 updatedAt: "2025-07-04T14:56:50.000Z"
+ *               time: "2025-07-04T14:56:50.406Z"
+ *               message: "Category deleted successfully"
+ *       '400':
+ *         $ref: '#/components/responses/BadRequest'
+ *       '401':
+ *         $ref: '#/components/responses/Unauthorized'
+ *       '403':
+ *         $ref: '#/components/responses/Forbidden'
+ *       '404':
+ *         description: Category not found
+ */
+
+router.delete(
+  "/:id",
+  checkPermissionByRole("admin"),
+  commonValidate([param("id").exists().bail().isInt({ gt: 0 })]),
+  deleteByIdAsync
+);
+
+/**
+ * @swagger
+ * /api/categories/{id}:
+ *   put:
+ *     summary: Update a category by ID (admin only)
+ *     description: Update an existing category's details including name, description, icon, and visibility.
+ *     tags:
+ *       - Category
+ *     security:
+ *       - cookieAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         description: The ID of the category to update
+ *         schema:
+ *           type: integer
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               name:
+ *                 type: string
+ *                 maxLength: 100
+ *                 example: "Frontend"
+ *               description:
+ *                 type: string
+ *                 example: "Courses related to frontend development"
+ *               icon:
+ *                 type: string
+ *                 maxLength: 255
+ *                 example: "frontend-icon.png"
+ *               isPublic:
+ *                 type: boolean
+ *                 example: true
+ *     responses:
+ *       200:
+ *         description: Category updated successfully
+ *         content:
+ *           application/json:
+ *             example:
+ *               isSuccess: true
+ *               status: 200
+ *               data:
+ *                 id: 1
+ *                 name: "Programming"
+ *                 description: "Coding courses"
+ *                 icon: ""
+ *                 parentId: null
+ *                 isPublic: true
+ *                 createdBy: 1
+ *                 updatedBy: 1
+ *                 isDeleted: false
+ *                 deletedAt: null
+ *                 createdAt: "2025-06-20T09:42:07.000Z"
+ *                 updatedAt: "2025-07-05T06:34:48.702Z"
+ *               time: "2025-07-05T06:34:48.705Z"
+ *               message: "Category updated successfully"
+ *       400:
+ *         $ref: '#/components/responses/BadRequest'
+ *       401:
+ *         $ref: '#/components/responses/Unauthorized'
+ *       403:
+ *         $ref: '#/components/responses/Forbidden'
+ *       404:
+ *         description: Category not found
+ */
+
+router.put(
+  "/:id",
+  checkPermissionByRole("admin"),
+  commonValidate([
+    param("id").exists().bail().isInt({ gt: 0 }),
+    body("name")
+      .optional()
+      .isString()
+      .isLength({ max: 100 })
+      .withMessage("Category name cannot exceed 100 characters"),
+    body("description").optional().isString(),
+    body("icon").optional().isString().isLength({ max: 255 }),
+    body("isPublic").optional().isBoolean(),
+  ]),
+  updateByIdAsync
 );
 
 module.exports = router;

--- a/service/categoryservice.js
+++ b/service/categoryservice.js
@@ -3,13 +3,10 @@ const { EntityAlreadyExistsException } = require("../common/commonError");
 const { Op } = require("sequelize");
 
 /**
- * Check if a category with the same name already exists under the same parent.
- * Used for both creation and update operations.
- * @param {string} name - Category name to check.
- * @param {number|null} parentId - Parent category ID (null for top-level categories).
- * @param {number|null} id - Current record ID (used to exclude self when updating).
+ * Check if a category with the same name and parentId already exists.
+ * Used to enforce unique category names under the same parent.
+ * Optionally excludes a given id (for update scenarios).
  */
-
 const checkCategoryNameExists = async (name, parentId, id = null) => {
   const whereClause = { name, parentId: parentId !== undefined ? parentId : null };
 
@@ -17,17 +14,20 @@ const checkCategoryNameExists = async (name, parentId, id = null) => {
     whereClause.id = { [Op.ne]: id };
   }
 
-  const existingCategory = await Category.findOne({
+  const isExisting = await Category.findOne({
     where: whereClause,
     attributes: ["id"],
     raw: true,
   });
 
-  if (existingCategory) {
-    throw new EntityAlreadyExistsException("Category name already exists under this parent");
+  if (isExisting) {
+    throw new EntityAlreadyExistsException("Category name already exists");
   }
 };
 
+/**
+ * Create a new category.
+ */
 const createCategoryAsync = async categoryData => {
   const { name, parentId } = categoryData;
 
@@ -38,6 +38,9 @@ const createCategoryAsync = async categoryData => {
   return newCategory;
 };
 
+/**
+ * Get a paginated list of categories with optional keyword search.
+ */
 const getAllCategoriesAsync = async (baseFilter, pagination = {}, keyword = null) => {
   const { offset, limit } = pagination;
 
@@ -58,8 +61,80 @@ const getAllCategoriesAsync = async (baseFilter, pagination = {}, keyword = null
   return categories;
 };
 
+/**
+ * Get category by primary key ID.
+ */
 const getCategoryByIdAsync = async id => {
   const category = await Category.findByPk(id);
+  return category;
+};
+
+/**
+ * Perform soft delete: mark category as deleted instead of removing it.
+ */
+const softDelete = async where => {
+  await Category.update(
+    {
+      isPublic: false,
+      isDeleted: true,
+      deletedAt: new Date(),
+    },
+    { where }
+  );
+
+  // Return list of IDs that were soft-deleted
+  const ids = Array.isArray(where.id) ? where.id : [where.id];
+  const rows = await Category.findAll({
+    attributes: ["id"],
+    where: { id: ids },
+    raw: true,
+  });
+  return rows.map(r => r.id);
+};
+
+/**
+ * Soft delete a single category by ID.
+ */
+const softDeleteCategoryByIdAsync = async id => {
+  const where = { id, isPublic: true, isDeleted: false };
+  const [deletedId] = await softDelete(where);
+
+  const deletedCategory = await Category.findByPk(deletedId);
+
+  return deletedCategory;
+};
+
+/**
+ * Soft delete multiple categories by a list of IDs.
+ */
+const softDeleteCategoriesByIdsAsync = async ids => {
+  const where = { id: ids, isPublic: true, isDeleted: false };
+  const deletedIds = await softDelete(where);
+
+  const deletedCategories = await Category.findAll({ where: { id: deletedIds } });
+
+  return deletedCategories;
+};
+
+/**
+ * Update a category by ID, ensuring name uniqueness.
+ */
+const updateCategoryByIdAsync = async (category, updateData, userId) => {
+  const { name, parentId } = updateData;
+
+  if (name !== undefined) {
+    await checkCategoryNameExists(
+      name,
+      parentId !== undefined ? parentId : category.parentId,
+      category.id
+    );
+  }
+
+  updateData.updatedBy = userId;
+  updateData.updatedAt = new Date();
+
+  await category.update(updateData);
+
   return category;
 };
 
@@ -67,4 +142,7 @@ module.exports = {
   createCategoryAsync,
   getAllCategoriesAsync,
   getCategoryByIdAsync,
+  softDeleteCategoryByIdAsync,
+  softDeleteCategoriesByIdsAsync,
+  updateCategoryByIdAsync,
 };

--- a/service/categoryservice.js
+++ b/service/categoryservice.js
@@ -1,0 +1,70 @@
+const { Category } = require("../models");
+const { EntityAlreadyExistsException } = require("../common/commonError");
+const { Op } = require("sequelize");
+
+/**
+ * Check if a category with the same name already exists under the same parent.
+ * Used for both creation and update operations.
+ * @param {string} name - Category name to check.
+ * @param {number|null} parentId - Parent category ID (null for top-level categories).
+ * @param {number|null} id - Current record ID (used to exclude self when updating).
+ */
+
+const checkCategoryNameExists = async (name, parentId, id = null) => {
+  const whereClause = { name, parentId: parentId !== undefined ? parentId : null };
+
+  if (id) {
+    whereClause.id = { [Op.ne]: id };
+  }
+
+  const existingCategory = await Category.findOne({
+    where: whereClause,
+    attributes: ["id"],
+    raw: true,
+  });
+
+  if (existingCategory) {
+    throw new EntityAlreadyExistsException("Category name already exists under this parent");
+  }
+};
+
+const createCategoryAsync = async categoryData => {
+  const { name, parentId } = categoryData;
+
+  await checkCategoryNameExists(name, parentId);
+
+  const newCategory = await Category.create(categoryData);
+
+  return newCategory;
+};
+
+const getAllCategoriesAsync = async (baseFilter, pagination = {}, keyword = null) => {
+  const { offset, limit } = pagination;
+
+  const keywordFilter = keyword ? { name: { [Op.like]: `%${keyword}%` } } : {};
+
+  const where = {
+    ...(baseFilter || {}),
+    ...keywordFilter,
+  };
+
+  const categories = await Category.findAndCountAll({
+    where,
+    offset,
+    limit,
+    order: [["createdAt", "DESC"]],
+  });
+
+  return categories;
+};
+
+const getCategoryByIdAsync = async id => {
+  const category = await Category.findByPk(id);
+  return category;
+};
+
+module.exports = {
+  createCategoryAsync,
+  getAllCategoriesAsync,
+  getCategoryByIdAsync,
+};

--- a/test/category.test.js
+++ b/test/category.test.js
@@ -9,10 +9,12 @@ describe("Category API CRUD", () => {
   let childId;
 
   beforeAll(async () => {
+    // Reset the database and disable FK checks temporarily
     await sequelize.query("SET FOREIGN_KEY_CHECKS = 0");
     await sequelize.sync({ force: true });
     await sequelize.query("SET FOREIGN_KEY_CHECKS = 1");
 
+    // Login as admin user and store token from cookie
     const loginRes = await request(app).post("/api/login").send({
       email: "alice@gmail.com",
       password: "password12",
@@ -24,20 +26,22 @@ describe("Category API CRUD", () => {
   });
 
   afterAll(async () => {
+    // Close DB connections after all tests
     await sequelize.close();
     await models.sequelize.close();
   });
 
-  test("POST /api/categories – create root category", async () => {
+  test("POST /api/categories – create parent category", async () => {
     const res = await request(app)
       .post("/api/categories")
       .set("Cookie", token)
-      .send({ name: "Root Cat", isPublic: true });
+      .send({ name: "Test Parent Category", isPublic: true });
 
     expect(res.statusCode).toBe(201);
     expect(res.body.data).toHaveProperty("id");
-    expect(res.body.data.name).toBe("Root Cat");
+    expect(res.body.data.name).toBe("Test Parent Category");
 
+    // Save parent category ID for future use
     rootId = res.body.data.id;
   });
 
@@ -45,11 +49,12 @@ describe("Category API CRUD", () => {
     const res = await request(app)
       .post("/api/categories")
       .set("Cookie", token)
-      .send({ name: "Child Cat", parentId: rootId, isPublic: true });
+      .send({ name: "Test Child Category", parentId: rootId, isPublic: true });
 
     expect(res.statusCode).toBe(201);
     expect(res.body.data.parentId).toBe(rootId);
 
+    // Save child category ID for later tests
     childId = res.body.data.id;
   });
 
@@ -79,6 +84,7 @@ describe("Category API CRUD", () => {
     expect(res.statusCode).toBe(200);
     const { list } = res.body.data;
 
+    // Ensure all returned categories have no parent
     expect(list.every(c => c.parentId === null)).toBe(true);
     expect(list.map(c => c.id)).toContain(rootId);
   });
@@ -89,7 +95,7 @@ describe("Category API CRUD", () => {
     expect(res.statusCode).toBe(200);
     expect(res.body.data).toMatchObject({
       id: childId,
-      name: "Child Cat",
+      name: "Test Child Category",
       parentId: rootId,
     });
   });
@@ -102,5 +108,51 @@ describe("Category API CRUD", () => {
 
     expect(list.every(c => c.parentId === rootId)).toBe(true);
     expect(list.map(c => c.id)).toContain(childId);
+  });
+
+  test("PUT /api/categories/:id – update category details", async () => {
+    const res = await request(app).put(`/api/categories/${rootId}`).set("Cookie", token).send({
+      name: "Updated Category Name",
+      description: "Updated description",
+      isPublic: true,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.data).toMatchObject({
+      id: rootId,
+      name: "Updated Category Name",
+      description: "Updated description",
+      isPublic: true,
+    });
+  });
+
+  test("DELETE /api/categories/:id – fail to delete category with children", async () => {
+    const res = await request(app).delete(`/api/categories/${rootId}`).set("Cookie", token);
+
+    // Deletion should fail due to existing child category
+    expect(res.statusCode).toBe(400);
+    expect(res.body.message).toMatch(/subcategories/i);
+  });
+
+  test("DELETE /api/categories/:id – delete child category successfully", async () => {
+    const res = await request(app).delete(`/api/categories/${childId}`).set("Cookie", token);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.data).toMatchObject({
+      id: childId,
+      isDeleted: true,
+      isPublic: false,
+    });
+  });
+
+  test("DELETE /api/categories/:id – delete parent after children removed", async () => {
+    const res = await request(app).delete(`/api/categories/${rootId}`).set("Cookie", token);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.data).toMatchObject({
+      id: rootId,
+      isDeleted: true,
+      isPublic: false,
+    });
   });
 });

--- a/test/category.test.js
+++ b/test/category.test.js
@@ -1,0 +1,106 @@
+const request = require("supertest");
+const app = require("../app");
+const { sequelize } = require("../db/sequelizedb");
+const models = require("../models");
+
+describe("Category API CRUD", () => {
+  let token;
+  let rootId;
+  let childId;
+
+  beforeAll(async () => {
+    await sequelize.query("SET FOREIGN_KEY_CHECKS = 0");
+    await sequelize.sync({ force: true });
+    await sequelize.query("SET FOREIGN_KEY_CHECKS = 1");
+
+    const loginRes = await request(app).post("/api/login").send({
+      email: "alice@gmail.com",
+      password: "password12",
+    });
+
+    expect(loginRes.statusCode).toBe(200);
+    token = loginRes.headers["set-cookie"].find(c => c.includes("token"));
+    expect(token).toBeDefined();
+  });
+
+  afterAll(async () => {
+    await sequelize.close();
+    await models.sequelize.close();
+  });
+
+  test("POST /api/categories – create root category", async () => {
+    const res = await request(app)
+      .post("/api/categories")
+      .set("Cookie", token)
+      .send({ name: "Root Cat", isPublic: true });
+
+    expect(res.statusCode).toBe(201);
+    expect(res.body.data).toHaveProperty("id");
+    expect(res.body.data.name).toBe("Root Cat");
+
+    rootId = res.body.data.id;
+  });
+
+  test("POST /api/categories – create child category", async () => {
+    const res = await request(app)
+      .post("/api/categories")
+      .set("Cookie", token)
+      .send({ name: "Child Cat", parentId: rootId, isPublic: true });
+
+    expect(res.statusCode).toBe(201);
+    expect(res.body.data.parentId).toBe(rootId);
+
+    childId = res.body.data.id;
+  });
+
+  test("GET /api/categories – should return paginated list with created categories", async () => {
+    const res = await request(app)
+      .get("/api/categories")
+      .set("Cookie", token)
+      .query({ page: 1, pageSize: 10 });
+
+    expect(res.statusCode).toBe(200);
+    const { list, pagination } = res.body.data;
+
+    const ids = list.map(c => c.id);
+    expect(ids).toEqual(expect.arrayContaining([rootId, childId]));
+
+    expect(pagination).toMatchObject({
+      page: 1,
+      pageSize: 10,
+      total: expect.any(Number),
+      totalPages: expect.any(Number),
+    });
+  });
+
+  test("GET /api/categories/root – should return only top-level categories", async () => {
+    const res = await request(app).get("/api/categories/root").set("Cookie", token);
+
+    expect(res.statusCode).toBe(200);
+    const { list } = res.body.data;
+
+    expect(list.every(c => c.parentId === null)).toBe(true);
+    expect(list.map(c => c.id)).toContain(rootId);
+  });
+
+  test("GET /api/categories/:id – should return specific category", async () => {
+    const res = await request(app).get(`/api/categories/${childId}`).set("Cookie", token);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.data).toMatchObject({
+      id: childId,
+      name: "Child Cat",
+      parentId: rootId,
+    });
+  });
+
+  test("GET /api/categories/:id/children – should return children of parent", async () => {
+    const res = await request(app).get(`/api/categories/${rootId}/children`).set("Cookie", token);
+
+    expect(res.statusCode).toBe(200);
+    const { list } = res.body.data;
+
+    expect(list.every(c => c.parentId === rootId)).toBe(true);
+    expect(list.map(c => c.id)).toContain(childId);
+  });
+});


### PR DESCRIPTION
**This PR implements the complete backend endpoint for the Course Category module in the MOOC system, including full CRUD functionality and supporting middleware. Key changes are as follows:**

- Create, Read, Update, and Soft Delete endpoints for course categories (/api/categories)
- Implemented pagination middleware with validation (page, pageSize)
- Enforced authentication using JWT tokens (from cookie)
- Enforced authorization via role-based access control (RBAC) middleware
- Added comprehensive integration tests using Jest + Supertest

The screenshots of test in the swagger document are attached. Please review the implementation and let me know if any adjustments are needed.

![Swagger-UI-07-05-2025_05_42_PM_part1](https://github.com/user-attachments/assets/73a4959c-9ec5-4937-a7d9-d1351e5c2f3a)
![Swagger-UI-07-05-2025_05_42_PM_part2](https://github.com/user-attachments/assets/79d53629-1969-46ca-81ab-65fd4ae359bc)